### PR TITLE
Add GitHub Pages Support

### DIFF
--- a/.github/pages.yml
+++ b/.github/pages.yml
@@ -1,0 +1,4 @@
+build:
+  html:
+    source: _site
+    destination: /

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,180 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  # Set this to your default branch
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      
+      - name: Copy static files
+        run: |
+          mkdir -p _site
+          cp -r templates/* _site/
+          # Use the static version of index.html
+          if [ -f _site/index.html.static ]; then
+            mv _site/index.html.static _site/index.html
+          fi
+          
+          # Create a simple API documentation page
+          cat > _site/api-docs.html << 'EOL'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+              <meta charset="UTF-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>PRIZM API Documentation</title>
+              <style>
+                  body {
+                      font-family: Arial, sans-serif;
+                      max-width: 800px;
+                      margin: 0 auto;
+                      padding: 20px;
+                      line-height: 1.6;
+                  }
+                  h1, h2, h3 {
+                      color: #333;
+                  }
+                  pre {
+                      background-color: #f5f5f5;
+                      padding: 10px;
+                      border-radius: 5px;
+                      overflow-x: auto;
+                  }
+                  code {
+                      font-family: monospace;
+                  }
+              </style>
+          </head>
+          <body>
+              <h1>PRIZM API Documentation</h1>
+              <p>This documentation describes how to use the PRIZM Code Lookup API.</p>
+              
+              <h2>API Endpoints</h2>
+              
+              <h3>Single Postal Code Lookup</h3>
+              <pre><code>GET /api/prizm?postal_code=V8A2P4</code></pre>
+              <p>Response:</p>
+              <pre><code>{
+                "postal_code": "V8A 2P4",
+                "prizm_code": "62",
+                "status": "success"
+              }</code></pre>
+              
+              <h3>Batch Postal Code Lookup</h3>
+              <pre><code>POST /api/prizm/batch
+          Content-Type: application/json
+          
+          {
+            "postal_codes": ["V8A2P4", "M5V2H1", "K1A0A9"]
+          }</code></pre>
+              <p>Response:</p>
+              <pre><code>{
+                "results": [
+                  {
+                    "postal_code": "V8A 2P4",
+                    "prizm_code": "62",
+                    "status": "success"
+                  },
+                  {
+                    "postal_code": "M5V 2H1",
+                    "prizm_code": "01",
+                    "status": "success"
+                  },
+                  {
+                    "postal_code": "K1A 0A9",
+                    "prizm_code": "11",
+                    "status": "success"
+                  }
+                ],
+                "total": 3,
+                "successful": 3
+              }</code></pre>
+              
+              <p><a href="index.html">Back to Home</a></p>
+          </body>
+          </html>
+          EOL
+          
+          # Create a simple README page
+          cat > _site/readme.html << 'EOL'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+              <meta charset="UTF-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>PRIZM Code Lookup - About</title>
+              <style>
+                  body {
+                      font-family: Arial, sans-serif;
+                      max-width: 800px;
+                      margin: 0 auto;
+                      padding: 20px;
+                      line-height: 1.6;
+                  }
+                  h1, h2, h3 {
+                      color: #333;
+                  }
+                  pre {
+                      background-color: #f5f5f5;
+                      padding: 10px;
+                      border-radius: 5px;
+                      overflow-x: auto;
+                  }
+                  code {
+                      font-family: monospace;
+                  }
+              </style>
+          </head>
+          <body>
+              <h1>PRIZM Code Lookup API</h1>
+              <p>This tool provides an API endpoint for users to submit Canadian postal codes and retrieve the associated PRIZM codes from Environics Analytics.</p>
+              
+              <h2>Features</h2>
+              <ul>
+                  <li>Single postal code lookup via GET request</li>
+                  <li>Batch postal code lookup via POST request</li>
+                  <li>Web interface for easy testing</li>
+                  <li>Parallel processing for batch requests</li>
+              </ul>
+              
+              <h2>How It Works</h2>
+              <ol>
+                  <li>The API receives a postal code request</li>
+                  <li>It uses Selenium to navigate to the PRIZM website</li>
+                  <li>It enters the postal code in the search field</li>
+                  <li>It extracts the PRIZM code from the search results</li>
+                  <li>It returns the result to the user</li>
+              </ol>
+              
+              <p><a href="index.html">Back to Home</a> | <a href="api-docs.html">API Documentation</a></p>
+          </body>
+          </html>
+          EOL
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 This tool provides an API endpoint for users to submit Canadian postal codes and retrieve the associated PRIZM codes from Environics Analytics.
 
+## Website
+
+A static demonstration of the API is available on GitHub Pages at:
+https://beaux-riel.github.io/prizm-api/
+
+The GitHub Pages site includes:
+- Static demonstration of the API interface
+- API documentation
+- Project information
+
+Note that the actual API functionality requires running the server locally or deploying it to your own server.
+
 ## Features
 
 - Single postal code lookup via GET request

--- a/templates/index.html.static
+++ b/templates/index.html.static
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PRIZM Code Lookup</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+        }
+        h1 {
+            color: #333;
+            text-align: center;
+        }
+        .container {
+            background-color: #f9f9f9;
+            border-radius: 5px;
+            padding: 20px;
+            margin-top: 20px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .form-group {
+            margin-bottom: 15px;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        input[type="text"], textarea {
+            width: 100%;
+            padding: 8px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            box-sizing: border-box;
+        }
+        button {
+            background-color: #4CAF50;
+            color: white;
+            padding: 10px 15px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        button:hover {
+            background-color: #45a049;
+        }
+        .result {
+            margin-top: 20px;
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            background-color: #fff;
+            display: none;
+        }
+        .api-info {
+            margin-top: 30px;
+            border-top: 1px solid #ddd;
+            padding-top: 20px;
+        }
+        code {
+            background-color: #f5f5f5;
+            padding: 2px 4px;
+            border-radius: 3px;
+            font-family: monospace;
+        }
+        .loading {
+            display: none;
+            text-align: center;
+            margin-top: 20px;
+        }
+        .spinner {
+            border: 4px solid #f3f3f3;
+            border-top: 4px solid #3498db;
+            border-radius: 50%;
+            width: 30px;
+            height: 30px;
+            animation: spin 2s linear infinite;
+            margin: 0 auto;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        .note {
+            background-color: #fffacd;
+            padding: 15px;
+            border-radius: 5px;
+            margin-bottom: 20px;
+            border-left: 4px solid #ffd700;
+        }
+        .nav-links {
+            text-align: center;
+            margin-top: 20px;
+            padding: 10px;
+            background-color: #f5f5f5;
+            border-radius: 5px;
+        }
+        .nav-links a {
+            margin: 0 10px;
+            text-decoration: none;
+            color: #4CAF50;
+            font-weight: bold;
+        }
+        .nav-links a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <h1>PRIZM Code Lookup</h1>
+    
+    <div class="nav-links">
+        <a href="index.html">Home</a> | 
+        <a href="api-docs.html">API Documentation</a> | 
+        <a href="readme.html">About</a>
+    </div>
+    
+    <div class="note">
+        <strong>Note:</strong> This is a static demonstration of the PRIZM Code Lookup API. 
+        The interactive features are not functional on this GitHub Pages site. 
+        To use the actual API, please clone the repository and run the server locally or deploy it to your own server.
+    </div>
+    
+    <div class="container">
+        <h2>Single Postal Code Lookup</h2>
+        <div class="form-group">
+            <label for="postal-code">Enter Canadian Postal Code:</label>
+            <input type="text" id="postal-code" placeholder="e.g., V8A 2P4" disabled>
+        </div>
+        <button disabled>Lookup PRIZM Code</button>
+        
+        <div class="result" style="display: block;">
+            <h3>Example Result</h3>
+            <p><strong>Postal Code:</strong> V8A 2P4</p>
+            <p><strong>PRIZM Code:</strong> 62</p>
+        </div>
+    </div>
+    
+    <div class="container">
+        <h2>Batch Postal Code Lookup</h2>
+        <div class="form-group">
+            <label for="batch-postal-codes">Enter Multiple Canadian Postal Codes (one per line):</label>
+            <textarea id="batch-postal-codes" rows="5" placeholder="e.g., V8A 2P4&#10;M5V 2H1&#10;K1A 0A9" disabled></textarea>
+        </div>
+        <button disabled>Lookup PRIZM Codes</button>
+        
+        <div class="result" style="display: block;">
+            <h3>Example Results (3 of 3 successful)</h3>
+            <table style="width:100%; border-collapse: collapse;">
+                <tr>
+                    <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">Postal Code</th>
+                    <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">PRIZM Code</th>
+                    <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">Status</th>
+                </tr>
+                <tr>
+                    <td style="border: 1px solid #ddd; padding: 8px;">V8A 2P4</td>
+                    <td style="border: 1px solid #ddd; padding: 8px;">62</td>
+                    <td style="border: 1px solid #ddd; padding: 8px;">success</td>
+                </tr>
+                <tr>
+                    <td style="border: 1px solid #ddd; padding: 8px;">M5V 2H1</td>
+                    <td style="border: 1px solid #ddd; padding: 8px;">01</td>
+                    <td style="border: 1px solid #ddd; padding: 8px;">success</td>
+                </tr>
+                <tr>
+                    <td style="border: 1px solid #ddd; padding: 8px;">K1A 0A9</td>
+                    <td style="border: 1px solid #ddd; padding: 8px;">11</td>
+                    <td style="border: 1px solid #ddd; padding: 8px;">success</td>
+                </tr>
+            </table>
+        </div>
+    </div>
+    
+    <div class="api-info">
+        <h2>API Documentation</h2>
+        <p>For detailed API documentation, please visit the <a href="api-docs.html">API Documentation</a> page.</p>
+        
+        <h3>Single Postal Code Lookup</h3>
+        <p>Endpoint: <code>GET /api/prizm?postal_code=V8A2P4</code></p>
+        <p>Response:</p>
+        <pre><code>{
+  "postal_code": "V8A 2P4",
+  "prizm_code": "62",
+  "status": "success"
+}</code></pre>
+        
+        <h3>Batch Postal Code Lookup</h3>
+        <p>Endpoint: <code>POST /api/prizm/batch</code></p>
+        <p>Request Body:</p>
+        <pre><code>{
+  "postal_codes": ["V8A2P4", "M5V2H1", "K1A0A9"]
+}</code></pre>
+        <p>Response:</p>
+        <pre><code>{
+  "results": [
+    {
+      "postal_code": "V8A 2P4",
+      "prizm_code": "62",
+      "status": "success"
+    },
+    {
+      "postal_code": "M5V 2H1",
+      "prizm_code": "01",
+      "status": "success"
+    },
+    {
+      "postal_code": "K1A 0A9",
+      "prizm_code": "11",
+      "status": "success"
+    }
+  ],
+  "total": 3,
+  "successful": 3
+}</code></pre>
+    </div>
+    
+    <div class="nav-links">
+        <a href="index.html">Home</a> | 
+        <a href="api-docs.html">API Documentation</a> | 
+        <a href="readme.html">About</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Description
This PR adds GitHub Pages support to the repository, allowing for a static demonstration of the PRIZM API interface.

## Changes
- Added GitHub Pages workflow configuration in `.github/workflows/github-pages.yml`
- Created a static version of the index.html file that works without backend functionality
- Added API documentation and About pages for the GitHub Pages site
- Updated README.md to include information about the GitHub Pages site
- Added `.nojekyll` file to prevent Jekyll processing

## How to Test
Once this PR is merged, the GitHub Pages site will be automatically deployed and accessible at https://beaux-riel.github.io/prizm-api/

## Notes
The GitHub Pages site is a static demonstration only. The actual API functionality requires running the server locally or deploying it to a server.