### PR TITLE
Harden PRIZM cache persistence

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@ __pycache__
 *.pyc
 *.db
 *.csv
+!prizm_import_*.csv
 debug_screenshots
 node_modules
 .DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           pip install -r requirements.txt ruff
 
       - name: Lint
-        run: ruff check app.py prizm_client.py cache_manager_new.py test_prizm_api.py
+        run: ruff check app.py prizm_client.py cache_manager_new.py cache_cli.py test_prizm_api.py
 
       - name: Test
         run: python -m unittest test_prizm_api.py

--- a/README.md
+++ b/README.md
@@ -88,13 +88,24 @@ Recommended Railway variables:
 PRIZM_API_KEY=<set-this-and-send-it-from-salesforce>
 MAX_BATCH_POSTAL_CODES=10
 PRIZM_CACHE_DB_PATH=/data/prizm_cache_v2.db
-PRIZM_CACHE_DURATION_DAYS=90
+PRIZM_SUCCESS_CACHE_DAYS=3650
+PRIZM_INVALID_CACHE_DAYS=90
+PRIZM_ERROR_CACHE_DAYS=30
 WEB_CONCURRENCY=2
 GUNICORN_THREADS=4
 GUNICORN_TIMEOUT=60
 ```
 
 If you set `PRIZM_CACHE_DB_PATH=/data/...`, add a Railway volume mounted at `/data` so cached lookups survive redeploys. The cache is optional; the API works without a persistent volume.
+
+To preload Railway's persistent cache from the existing CSV export, run this in a Railway shell after the volume is mounted:
+
+```bash
+python cache_cli.py import-csv prizm_import_09112025.csv --replace
+python cache_cli.py stats
+```
+
+Successful lookups default to a 10-year cache, invalid postal-code formats default to 90 days, and cacheable not-found/error results default to 30 days. Upstream quota/network failures are not cached.
 
 When `PRIZM_API_KEY` is set, all `/api/*` routes require either:
 

--- a/app.py
+++ b/app.py
@@ -18,6 +18,15 @@ app = Flask(__name__)
 prizm_client = PrizmClient()
 
 
+def cache_duration_for_result(result: Dict[str, Any]) -> int:
+    status = result.get("status")
+    if status == "success":
+        return int(os.environ.get("PRIZM_SUCCESS_CACHE_DAYS", "3650"))
+    if status == "invalid":
+        return int(os.environ.get("PRIZM_INVALID_CACHE_DAYS", "90"))
+    return int(os.environ.get("PRIZM_ERROR_CACHE_DAYS", "30"))
+
+
 @app.before_request
 def require_api_key():
     expected_key = os.environ.get("PRIZM_API_KEY")
@@ -84,7 +93,7 @@ def get_prizm_code(postal_code: str) -> Dict[str, Any]:
         }
 
     if should_cache:
-        cache_duration = 7 if result["status"] == "error" else None
+        cache_duration = cache_duration_for_result(result)
         cache_manager.cache_data(cache_key, result, custom_duration_days=cache_duration)
     return result
 

--- a/cache_cli.py
+++ b/cache_cli.py
@@ -4,9 +4,65 @@ CLI tool for managing the PRIZM API cache
 """
 
 import argparse
+import csv
 import json
 import sys
 from cache_manager_new import cache_manager
+
+
+IMPORT_FIELDS = [
+    "postal_code",
+    "segment_number",
+    "segment_name",
+    "segment_description",
+    "who_they_are",
+    "average_household_income",
+    "education",
+    "urbanity",
+    "average_household_net_worth",
+    "occupation",
+    "diversity",
+    "family_life",
+    "tenure",
+    "home_type",
+    "status",
+]
+
+
+def import_csv(path, success_days, invalid_days, error_days, replace):
+    imported = 0
+    skipped = 0
+    failed = 0
+
+    with open(path, newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            postal_code = (row.get("postal_code") or "").strip()
+            if not postal_code:
+                skipped += 1
+                continue
+
+            if not replace and cache_manager.is_cached(postal_code):
+                skipped += 1
+                continue
+
+            status = (row.get("status") or "error").strip().lower()
+            data = {field: (row.get(field) or "").strip() for field in IMPORT_FIELDS}
+            data["status"] = status
+
+            if status == "success":
+                duration_days = success_days
+            elif status == "invalid":
+                duration_days = invalid_days
+            else:
+                duration_days = error_days
+
+            if cache_manager.cache_data(postal_code, data, custom_duration_days=duration_days):
+                imported += 1
+            else:
+                failed += 1
+
+    return imported, skipped, failed
 
 
 def main():
@@ -14,10 +70,10 @@ def main():
     subparsers = parser.add_subparsers(dest='command', help='Available commands')
     
     # Stats command
-    stats_parser = subparsers.add_parser('stats', help='Show cache statistics')
+    subparsers.add_parser('stats', help='Show cache statistics')
     
     # Cleanup command
-    cleanup_parser = subparsers.add_parser('cleanup', help='Clean up expired cache entries')
+    subparsers.add_parser('cleanup', help='Clean up expired cache entries')
     
     # Clear command
     clear_parser = subparsers.add_parser('clear', help='Clear all cache entries')
@@ -51,6 +107,14 @@ def main():
     # Migrate command
     migrate_parser = subparsers.add_parser('migrate', help='Migrate database to new schema')
     migrate_parser.add_argument('--no-backup', action='store_true', help='Skip creating backup')
+
+    # Import command
+    import_parser = subparsers.add_parser('import-csv', help='Import cached PRIZM results from a CSV export')
+    import_parser.add_argument('path', help='CSV file to import')
+    import_parser.add_argument('--success-days', type=int, default=3650, help='Cache duration for successful lookups')
+    import_parser.add_argument('--invalid-days', type=int, default=90, help='Cache duration for invalid postal codes')
+    import_parser.add_argument('--error-days', type=int, default=30, help='Cache duration for non-quota error results')
+    import_parser.add_argument('--replace', action='store_true', help='Replace existing valid cache entries')
     
     args = parser.parse_args()
     
@@ -71,7 +135,7 @@ def main():
             # Show status breakdown if available
             status_breakdown = stats.get('status_breakdown', {})
             if status_breakdown:
-                print(f"  Status breakdown:")
+                print("  Status breakdown:")
                 for status, count in status_breakdown.items():
                     print(f"    - {status}: {count}")
             
@@ -191,6 +255,18 @@ def main():
                 print("\n✅ Migration completed successfully!")
             else:
                 print("\n❌ Migration failed! Check the logs for details.")
+                return 1
+
+        elif args.command == 'import-csv':
+            imported, skipped, failed = import_csv(
+                args.path,
+                success_days=args.success_days,
+                invalid_days=args.invalid_days,
+                error_days=args.error_days,
+                replace=args.replace,
+            )
+            print(f"Imported {imported} rows, skipped {skipped}, failed {failed}")
+            if failed:
                 return 1
                 
     except Exception as e:

--- a/cache_manager_new.py
+++ b/cache_manager_new.py
@@ -44,8 +44,8 @@ class CacheManager:
             return f"{compact[:3]} {compact[3:]}"
         return postal_code.strip().upper()
     
-    def _parse_currency_to_int(self, value: Optional[str]) -> Optional[int]:
-        """Convert currency string like '$95,199' to integer 95199."""
+    def _parse_currency_to_int(self, value: Optional[str]) -> Optional[Any]:
+        """Convert simple currency strings to integers; keep ranges as text."""
         if not value or value == '' or value == 'Unknown':
             return None
         
@@ -55,13 +55,14 @@ class CacheManager:
         try:
             return int(cleaned)
         except (ValueError, TypeError):
-            logger.warning(f"Could not parse currency value: {value}")
-            return None
+            return str(value).strip()
     
-    def _format_currency_from_int(self, value: Optional[int]) -> Optional[str]:
-        """Convert integer 95199 to currency string '$95,199'."""
+    def _format_currency_from_int(self, value: Optional[Any]) -> Optional[str]:
+        """Convert integer 95199 to '$95,199'; return range labels unchanged."""
         if value is None:
             return None
+        if isinstance(value, str):
+            return value if value.startswith("$") else f"${value}"
         
         # Format with comma separators and dollar sign
         return f"${value:,}"

--- a/test_prizm_api.py
+++ b/test_prizm_api.py
@@ -3,8 +3,8 @@ import os
 import unittest
 from unittest.mock import patch
 
-from app import app
-from prizm_client import normalize_postal_code
+from app import app, cache_duration_for_result
+from prizm_client import PrizmLookupError, normalize_postal_code
 
 
 LOOKUP_RESULT = {
@@ -56,7 +56,23 @@ class TestPrizmAPI(unittest.TestCase):
         self.assertEqual(data["prizm_code"], "21")
         lookup.assert_called_once_with("V8A0A8")
         get_cached_data.assert_called_once_with("V8A 0A8")
-        cache_data.assert_called_once()
+        cache_data.assert_called_once_with("V8A 0A8", LOOKUP_RESULT, custom_duration_days=3650)
+
+    def test_cache_duration_for_result(self):
+        self.assertEqual(cache_duration_for_result({"status": "success"}), 3650)
+        self.assertEqual(cache_duration_for_result({"status": "invalid"}), 90)
+        self.assertEqual(cache_duration_for_result({"status": "error"}), 30)
+
+    @patch("app.cache_manager.cache_data", return_value=True)
+    @patch("app.cache_manager.get_cached_data", return_value=None)
+    @patch("app.prizm_client.lookup", side_effect=PrizmLookupError("quota exceeded"))
+    def test_upstream_exceptions_are_not_cached(self, _lookup, _get_cached_data, cache_data):
+        response = self.client.get("/api/prizm?postal_code=V8A0A8")
+        data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["status"], "error")
+        cache_data.assert_not_called()
 
     @patch("app.cache_manager.cache_data", return_value=True)
     @patch("app.cache_manager.get_cached_data", return_value=None)


### PR DESCRIPTION
## Summary

- make PRIZM cache durations status-aware: successful lookups default to 10 years, invalid formats to 90 days, cacheable errors to 30 days
- keep upstream quota/network failures out of the cache so 403s do not poison future Salesforce calls
- add `cache_cli.py import-csv` for seeding Railway persistent volumes from existing PRIZM CSV exports
- preserve currency range labels from existing cache exports during import
- include `prizm_import_*.csv` files in Docker images so Railway shells can seed cache from bundled exports

## Railway cache seed

After mounting a Railway volume at `/data` and setting `PRIZM_CACHE_DB_PATH=/data/prizm_cache_v2.db`:

```bash
python cache_cli.py import-csv prizm_import_09112025.csv --replace
python cache_cli.py stats
```

## Verification

- `ruff check app.py prizm_client.py cache_manager_new.py cache_cli.py test_prizm_api.py`
- `python -m unittest test_prizm_api.py`
- `npm test -- --runInBand`
- `npm run build`
- imported `prizm_import_09112025.csv` into a temp SQLite cache and confirmed `V8S 5C1` returned from cache with income/net-worth ranges preserved
