### PR TITLE
Require API key on all routes except /health

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ def cache_duration_for_result(result: Dict[str, Any]) -> int:
 @app.before_request
 def require_api_key():
     expected_key = os.environ.get("PRIZM_API_KEY")
-    if not expected_key or not request.path.startswith("/api/") or request.method == "OPTIONS":
+    if not expected_key or request.path == "/health" or request.method == "OPTIONS":
         return None
 
     provided_key = request.headers.get("X-API-Key")

--- a/test_prizm_api.py
+++ b/test_prizm_api.py
@@ -98,11 +98,16 @@ class TestPrizmAPI(unittest.TestCase):
         response = self.client.post("/api/prizm/batch", json={"postal_codes": ["V8A0A8"] * 11})
         self.assertEqual(response.status_code, 400)
 
-    def test_optional_api_key_protection(self):
+    def test_api_key_protects_all_routes_except_health(self):
         os.environ["PRIZM_API_KEY"] = "secret"
         try:
-            response = self.client.get("/api/segments")
-            self.assertEqual(response.status_code, 401)
+            self.assertEqual(self.client.get("/").status_code, 401)
+            self.assertEqual(self.client.get("/api/segments").status_code, 401)
+
+            self.assertEqual(self.client.get("/health").status_code, 200)
+            self.assertEqual(
+                self.client.get("/", headers={"X-API-Key": "secret"}).status_code, 200
+            )
 
             with patch("app.prizm_client.get_all_segments", return_value=[]):
                 response = self.client.get("/api/segments", headers={"X-API-Key": "secret"})


### PR DESCRIPTION
## Summary
The live deploy was still serving the root index without authentication. Root cause: the `before_request` gate in `app.py` only matched `/api/*` paths, so `/` (and any non-`/api/` route) was reachable without a key.

- Gate **every** request except `/health` (Railway healthcheck) and `OPTIONS` preflight
- Update the auth test to assert `/` returns 401 without a key and 200 with it

This is the auth-narrowing issue from PR #9 that didn't actually land in the merged code.

## Test plan
- [x] `python -m unittest test_prizm_api` — all 10 pass
- [ ] After merge + Railway deploy: `curl /` -> 401, `curl -H "X-API-Key: <key>" /` -> 200 JSON, `curl /health` -> 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)