### PR TITLE
Add PRIZM segment 24 net worth

### DIFF
--- a/segment_net_worth.py
+++ b/segment_net_worth.py
@@ -29,6 +29,10 @@ AVERAGE_HOUSEHOLD_NET_WORTH_BY_SEGMENT = {
     21: 1255437,
     22: 988892,
     23: 973823,
+    # PRIZM 2020 guide, segment 24 All-Terrain Families. The current Supabase
+    # reference table omits net worth; this keeps Salesforce picklist mapping
+    # populated for postal codes assigned to this segment.
+    24: 334508,
     25: 916822,
     28: 640083,
     30: 780256,


### PR DESCRIPTION
## Summary
- add verified segment 24 All-Terrain Families net worth source value from the public PRIZM 2020 guide
- enables Salesforce-safe net worth bucket mapping for postal codes assigned to segment 24

## Verification
- .venv/bin/python -m unittest test_prizm_api.py
- Railway production deployment a63a9eeb-3dd4-4f15-952c-28192009d354 succeeded
- Live smoke: V0R1S0 returns segment 24, average_household_net_worth '/bin/zsh to K', average_household_net_worth_amount 334508